### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 15
@@ -23,7 +23,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -41,8 +41,7 @@ task clean(type: Delete) {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.1'
-    compile 'com.facebook.react:react-native:0.17.+'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.facebook.react:react-native:0.17.0'
 }


### PR DESCRIPTION
Update dependencies to fix these lint warnings

```
GradleDependency: Obsolete Gradle Dependency
../../build.gradle:45: A newer version of com.android.support:appcompat-v7 than 23.1.1 is available: 23.4.0
  42 
  43 dependencies {
  44     testCompile 'junit:junit:4.12'
  45     compile 'com.android.support:appcompat-v7:23.1.1'
  46     compile 'com.facebook.react:react-native:0.17.+'
  47 }
Note: This issue has an associated quickfix operation in Android Studio/IntelliJ Fix 
Priority: 4 / 10
Category: Correctness
Severity: Warning
Explanation: Obsolete Gradle Dependency.
This detector looks for usages of libraries where the version you are using is not the current stable release. Using older versions is fine, and there are cases where you deliberately want to stick with an older version. However, you may simply not be aware that a more recent version is available, and that is what this lint check helps find.
```

```
GradleDynamicVersion: Gradle Dynamic Version
../../build.gradle:46: Avoid using + in version numbers; can lead to unpredictable and unrepeatable builds (com.facebook.react:react-native:0.17.+)
  43 dependencies {
  44     testCompile 'junit:junit:4.12'
  45     compile 'com.android.support:appcompat-v7:23.1.1'
  46     compile 'com.facebook.react:react-native:0.17.+'
  47 }
  48 
Note: This issue has an associated quickfix operation in Android Studio/IntelliJ Fix 
Priority: 4 / 10
Category: Correctness
Severity: Warning
Explanation: Gradle Dynamic Version.
Using + in dependencies lets you automatically pick up the latest available version rather than a specific, named version. However, this is not recommended; your builds are not repeatable; you may have tested with a slightly different version than what the build server used. (Using a dynamic version as the major version number is more problematic than using it in the minor version position.)
```
