### PR TITLE
Resolve lint error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    lintOptions {
+       warning 'InvalidPackage'
+    }
 }
 
 buildscript {


### PR DESCRIPTION
Another solution to resolve the lint error 

https://github.com/JoaoCnh/react-native-android-voice/pull/12

```
InvalidPackage: Package not included in Android
../../../../../../.gradle/caches/modules-2/files-2.1/com.squareup.okio/okio/1.6.0/98476622f10715998eacf9240d6b479f12c66143/okio-1.6.0.jar: Invalid package reference in library; not included in Android: java.nio.file. Referenced from okio.Okio.
Priority: 6 / 10
Category: Correctness
Severity: Error
Explanation: Package not included in Android.
This check scans through libraries looking for calls to APIs that are not included in Android.

When you create Android projects, the classpath is set up such that you can only access classes in the API packages that are included in Android. However, if you add other projects to your libs/ folder, there is no guarantee that those .jar files were built with an Android specific classpath, and in particular, they could be accessing unsupported APIs such as java.applet.

This check scans through library jars and looks for references to API packages that are not included in Android and flags these. This is only an error if your code calls one of the library classes which wind up referencing the unsupported package.

More info:

To suppress this error, use the issue id "InvalidPackage" as explained in the Suppressing Warnings and Errors section.
```
