### PR TITLE
Condition for missing/disabled Google Search

### DIFF
--- a/src/main/java/com/wmjmc/reactspeech/VoiceModule.java
+++ b/src/main/java/com/wmjmc/reactspeech/VoiceModule.java
@@ -67,6 +67,12 @@ public class VoiceModule extends ReactContextBaseJavaModule implements ActivityE
                 mVoicepromise = null;
             }
         }
+        else{
+            Toast.makeText(getReactApplicationContext(),"Please enable Google Search!", Toast.LENGTH_SHORT).show();
+            Intent redirectToPlayStore= new Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=com.google.android.googlequicksearchbox"));
+            redirectToPlayStore.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            this.reactContext.startActivity(redirectToPlayStore);
+        }
     }
 
     @Override


### PR DESCRIPTION
In some cases, the default Google Search might to disabled. This `else` condition would redirect the user to Play Store where they can enable it.