### PR TITLE
Remove extra onNewIntent

### DIFF
--- a/src/main/java/com/wmjmc/reactspeech/VoiceModule.java
+++ b/src/main/java/com/wmjmc/reactspeech/VoiceModule.java
@@ -125,10 +125,6 @@ public class VoiceModule extends ReactContextBaseJavaModule implements ActivityE
         return "Say something";
     }
 
-    public void onNewIntent(Intent intent) {
-        // no-op
-    }
-
     private String getLocale(String locale){
         if(locale != null && !locale.equals("")){
             return locale;


### PR DESCRIPTION
It is failing for me because of extra `onNewIntent`.

```
 ...node_modules/react-native-android-voice/src/main/java/com/wmjmc/reactspeech/VoiceModule.java:128: error: method onNewIntent(Intent) is already defined in class VoiceModule
    public void onNewIntent(Intent intent) {
                ^
```