### PR TITLE
Remove clean task for new version Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,6 @@ buildscript {
     }
 }
 
-task clean(type: Delete) {
-    delete rootProject.buildDir
-}
-
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Fix error building app
========================
* What went wrong:
A problem occurred evaluating project ':VoiceModule'.
> Declaring custom 'clean' task when using the standard Gradle lifecycle plugins is not allowed.
