### PR TITLE
React Native 0.47 support

### DIFF
--- a/src/main/java/com/wmjmc/reactspeech/VoicePackage.java
+++ b/src/main/java/com/wmjmc/reactspeech/VoicePackage.java
@@ -24,7 +24,6 @@ public class VoicePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
The React Native 0.47 has removed the createJSModules method in ReactPackage. Therefore any overrides of this method has to be removed.

See: facebook/react-native@ce6fb33